### PR TITLE
Fix spacing for all if statements

### DIFF
--- a/client/hostinfo_win.cpp
+++ b/client/hostinfo_win.cpp
@@ -378,14 +378,14 @@ int get_os_information(
         case VER_PLATFORM_WIN32_NT:
 
             if ( osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0) {
-                if( osvi.wProductType == VER_NT_WORKSTATION ) {
+                if ( osvi.wProductType == VER_NT_WORKSTATION ) {
                     if ( osvi.dwBuildNumber >= 22000 ) {
                         strlcat(os_name, "Windows 11", os_name_size);
                     } else {
                         strlcat(os_name, "Windows 10", os_name_size);
                     }
                 } else {
-                    if  (osvi.dwBuildNumber >= 26100) {
+                    if (osvi.dwBuildNumber >= 26100) {
 			            strlcat(os_name, "Windows Server 2025", os_name_size);
 		            } else if (osvi.dwBuildNumber >= 25398) {
                         strlcat(os_name, "Windows Server 23H2", os_name_size);
@@ -401,7 +401,7 @@ int get_os_information(
             }
 
             if ( osvi.dwMajorVersion == 6 && osvi.dwMinorVersion == 4 ) {
-                if( osvi.wProductType == VER_NT_WORKSTATION ) {
+                if ( osvi.wProductType == VER_NT_WORKSTATION ) {
                     strlcat(os_name, "Windows 10 Beta", os_name_size);
                 } else {
                     strlcat(os_name, "Windows 10 Server Beta", os_name_size);
@@ -410,7 +410,7 @@ int get_os_information(
             }
 
             if ( osvi.dwMajorVersion == 6 && osvi.dwMinorVersion == 3 ) {
-                if( osvi.wProductType == VER_NT_WORKSTATION ) {
+                if ( osvi.wProductType == VER_NT_WORKSTATION ) {
                     strlcat(os_name, "Windows 8.1", os_name_size);
                 } else {
                     strlcat(os_name, "Windows Server 2012 R2", os_name_size);
@@ -419,7 +419,7 @@ int get_os_information(
             }
 
             if ( osvi.dwMajorVersion == 6 && osvi.dwMinorVersion == 2 ) {
-                if( osvi.wProductType == VER_NT_WORKSTATION ) {
+                if ( osvi.wProductType == VER_NT_WORKSTATION ) {
                     strlcat(os_name, "Windows 8", os_name_size);
                 } else {
                     strlcat(os_name, "Windows Server 2012", os_name_size);
@@ -428,7 +428,7 @@ int get_os_information(
             }
 
             if ( osvi.dwMajorVersion == 6 && osvi.dwMinorVersion == 1 ) {
-                if( osvi.wProductType == VER_NT_WORKSTATION ) {
+                if ( osvi.wProductType == VER_NT_WORKSTATION ) {
                     strlcat(os_name, "Windows 7", os_name_size);
                 } else {
                     strlcat(os_name, "Windows Server 2008 \"R2\"", os_name_size);
@@ -437,7 +437,7 @@ int get_os_information(
             }
 
             if ( osvi.dwMajorVersion == 6 && osvi.dwMinorVersion == 0 ) {
-                if( osvi.wProductType == VER_NT_WORKSTATION ) {
+                if ( osvi.wProductType == VER_NT_WORKSTATION ) {
                     strlcat(os_name, "Windows Vista", os_name_size);
                 } else {
                     strlcat(os_name, "Windows Server 2008", os_name_size);
@@ -446,10 +446,10 @@ int get_os_information(
             }
 
             if ( osvi.dwMajorVersion == 5 && osvi.dwMinorVersion == 2 ) {
-                if( osvi.wProductType == VER_NT_WORKSTATION) {
+                if ( osvi.wProductType == VER_NT_WORKSTATION) {
                     strlcat(os_name, "Windows XP", os_name_size);
                 } else {
-                    if( GetSystemMetrics(SM_SERVERR2) ) {
+                    if ( GetSystemMetrics(SM_SERVERR2) ) {
                         strlcat(os_name, "Windows Server 2003 \"R2\"", os_name_size);
                     } else {
                         strlcat(os_name, "Windows Server 2003", os_name_size);
@@ -504,13 +504,13 @@ int get_os_information(
         case VER_PLATFORM_WIN32_NT:
 
             // Test for specific product on Windows NT 4.0 SP6 and later.
-            if( bOsVersionInfoEx ) {
+            if ( bOsVersionInfoEx ) {
 
                 // Test for the workstation type.
                 if ( osvi.wProductType == VER_NT_WORKSTATION ) {
 
                     // all NT6 or higher have dwType (Vista,7,8,81,10...)
-                    if( (osvi.dwMajorVersion >= 6) ) {
+                    if ( (osvi.dwMajorVersion >= 6) ) {
                         switch(dwType) {
                             case PRODUCT_BUSINESS:
                                 safe_strcat(szSKU, "Business ");
@@ -646,33 +646,33 @@ int get_os_information(
                                 break;
                         }
 
-                    } else if( (osvi.dwMajorVersion == 5 && osvi.dwMinorVersion == 2) ) {
+                    } else if ( (osvi.dwMajorVersion == 5 && osvi.dwMinorVersion == 2) ) {
 
-                        if( osvi.wSuiteMask & VER_SUITE_PERSONAL ) {
+                        if ( osvi.wSuiteMask & VER_SUITE_PERSONAL ) {
                             safe_strcat(szSKU, "Home ");
                         } else {
                             safe_strcat(szSKU, "Professional ");
                         }
 
-                    } else if( (osvi.dwMajorVersion == 5 && osvi.dwMinorVersion == 1) ) {
+                    } else if ( (osvi.dwMajorVersion == 5 && osvi.dwMinorVersion == 1) ) {
 
-                        if( osvi.wSuiteMask & VER_SUITE_PERSONAL ) {
+                        if ( osvi.wSuiteMask & VER_SUITE_PERSONAL ) {
                             safe_strcat(szSKU, "Home ");
-                        } else if( GetSystemMetrics(SM_TABLETPC) ) {
+                        } else if ( GetSystemMetrics(SM_TABLETPC) ) {
                             safe_strcat(szSKU, "Tablet PC ");
-                        } else if( GetSystemMetrics(SM_MEDIACENTER) ) {
+                        } else if ( GetSystemMetrics(SM_MEDIACENTER) ) {
                             safe_strcat(szSKU, "Media Center ");
-                        } else if( GetSystemMetrics(SM_STARTER) ) {
+                        } else if ( GetSystemMetrics(SM_STARTER) ) {
                             safe_strcat(szSKU, "Starter ");
                         } else {
                             safe_strcat(szSKU, "Professional ");
                         }
 
-                    } else if( (osvi.dwMajorVersion == 5 && osvi.dwMinorVersion == 0) ) {
+                    } else if ( (osvi.dwMajorVersion == 5 && osvi.dwMinorVersion == 0) ) {
 
                         safe_strcat(szSKU, "Professional ");
 
-                    } else if(  (osvi.dwMajorVersion == 4 && osvi.dwMinorVersion == 0) ) {
+                    } else if (  (osvi.dwMajorVersion == 4 && osvi.dwMinorVersion == 0) ) {
 
                         safe_strcat(szSKU, "Workstation ");
 
@@ -683,7 +683,7 @@ int get_os_information(
                 else if ( (osvi.wProductType == VER_NT_SERVER) || (osvi.wProductType == VER_NT_DOMAIN_CONTROLLER) ) {
 
                     // all NT6 or higher (Server 2008,2008r2,2012,2012r2,2015...)
-                    if( (osvi.dwMajorVersion >= 6) ) {
+                    if ( (osvi.dwMajorVersion >= 6) ) {
                         switch(dwType) {
                             case PRODUCT_ARM64_SERVER:
                                 safe_strcat(szSKU, "ARM64 Server ");
@@ -882,11 +882,11 @@ int get_os_information(
                                 break;
                         }
 
-                    } else if( (osvi.dwMajorVersion == 5 && osvi.dwMinorVersion == 2) ) {
+                    } else if ( (osvi.dwMajorVersion == 5 && osvi.dwMinorVersion == 2) ) {
 
-                        if( osvi.wSuiteMask & VER_SUITE_DATACENTER ) {
+                        if ( osvi.wSuiteMask & VER_SUITE_DATACENTER ) {
                             safe_strcat( szSKU, "Datacenter Server " );
-                        } else if( osvi.wSuiteMask & VER_SUITE_ENTERPRISE ) {
+                        } else if ( osvi.wSuiteMask & VER_SUITE_ENTERPRISE ) {
                             safe_strcat( szSKU, "Enterprise Server " );
                         } else if ( osvi.wSuiteMask & VER_SUITE_BLADE ) {
                             safe_strcat( szSKU, "Web Server " );
@@ -896,18 +896,18 @@ int get_os_information(
                             safe_strcat( szSKU, "Standard Server " );
                         }
 
-                    } else if( osvi.dwMajorVersion == 5 && osvi.dwMinorVersion == 0 ) {
+                    } else if ( osvi.dwMajorVersion == 5 && osvi.dwMinorVersion == 0 ) {
 
-                        if( osvi.wSuiteMask & VER_SUITE_DATACENTER ) {
+                        if ( osvi.wSuiteMask & VER_SUITE_DATACENTER ) {
                             safe_strcat( szSKU, "Datacenter Server " );
-                        } else if( osvi.wSuiteMask & VER_SUITE_ENTERPRISE ) {
+                        } else if ( osvi.wSuiteMask & VER_SUITE_ENTERPRISE ) {
                             safe_strcat( szSKU, "Advanced Server " );
                         } else {
                             safe_strcat( szSKU, "Standard Server " );
                         }
 
                     } else { // Windows NT 4.0
-                        if( osvi.wSuiteMask & VER_SUITE_ENTERPRISE ) {
+                        if ( osvi.wSuiteMask & VER_SUITE_ENTERPRISE ) {
                             safe_strcat( szSKU, "Enterprise Server " );
                         } else {
                             safe_strcat( szSKU, "Server " );
@@ -961,12 +961,12 @@ int get_os_information(
                 lRet = RegOpenKeyEx( HKEY_LOCAL_MACHINE,
                     "SYSTEM\\CurrentControlSet\\Control\\ProductOptions",
                     0, KEY_QUERY_VALUE, &hKey );
-                if( lRet != ERROR_SUCCESS )
+                if ( lRet != ERROR_SUCCESS )
                     return FALSE;
 
                 lRet = RegQueryValueEx( hKey, "ProductType", NULL, NULL,
                     (LPBYTE) szProductType, &dwBufLen);
-                if( (lRet != ERROR_SUCCESS) || (dwBufLen > 80) )
+                if ( (lRet != ERROR_SUCCESS) || (dwBufLen > 80) )
                     return FALSE;
 
                 RegCloseKey( hKey );
@@ -982,7 +982,7 @@ int get_os_information(
             }
 
             // Display service pack (if any) and build number.
-            if( osvi.dwMajorVersion == 4 && lstrcmpi( osvi.szCSDVersion, "Service Pack 6" ) == 0
+            if ( osvi.dwMajorVersion == 4 && lstrcmpi( osvi.szCSDVersion, "Service Pack 6" ) == 0
             ) {
                 HKEY hKey;
                 LONG lRet;
@@ -992,7 +992,7 @@ int get_os_information(
                     "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Hotfix\\Q246009",
                     0, KEY_QUERY_VALUE, &hKey );
 
-                if( lRet == ERROR_SUCCESS ) {
+                if ( lRet == ERROR_SUCCESS ) {
                     safe_strcpy( szServicePack, ", " );
                     safe_strcat( szServicePack, "Service Pack 6a" );
                 } else {// Windows NT 4.0 prior to SP6a
@@ -1570,18 +1570,18 @@ int HOST_INFO::get_virtualbox_version() {
         lRet = RegQueryValueEx(hKey, "InstallDir", NULL, NULL,
             (LPBYTE) szInstallDir, &dwInstallDir
         );
-        if((lRet != ERROR_SUCCESS) || (dwInstallDir > sizeof(szInstallDir))) {
+        if ((lRet != ERROR_SUCCESS) || (dwInstallDir > sizeof(szInstallDir))) {
             return 1;
         }
 
         lRet = RegQueryValueEx(
             hKey, "VersionExt", NULL, NULL, (LPBYTE) szVersion, &dwVersion
         );
-        if((lRet != ERROR_SUCCESS) || (dwVersion > sizeof(szVersion))) {
+        if ((lRet != ERROR_SUCCESS) || (dwVersion > sizeof(szVersion))) {
             lRet = RegQueryValueEx(
                 hKey, "Version", NULL, NULL, (LPBYTE) szVersion, &dwVersion
             );
-            if((lRet != ERROR_SUCCESS) || (dwVersion > sizeof(szVersion))) {
+            if ((lRet != ERROR_SUCCESS) || (dwVersion > sizeof(szVersion))) {
                 return 1;
             }
         }


### PR DESCRIPTION
## Summary
- standardize spacing after `if` in `hostinfo_win.cpp`

## Testing
- `grep -n "if(" client/hostinfo_win.cpp`