### PR TITLE
Improve INSTALL server docs

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -16,3 +16,20 @@ you can build and install BOINC libraries using [vcpkg](https://github.com/Micro
     ./vcpkg install boinc
 
 The BOINC port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
+To build the BOINC server components use the normal configure and make steps
+without `--disable-server`:
+
+    ./_autosetup
+    ./configure
+    make
+
+More detailed information about setting up a server can be found on the
+BOINC wiki (<https://boinc.berkeley.edu/trac/wiki/ServerIntro>).
+
+If you prefer downloading the dependencies yourself instead of using vcpkg,
+have a look at the helper scripts in the `3rdParty` directory.  They fetch and
+build the required libraries on Linux and macOS:
+
+    ./3rdParty/buildLinuxDependencies.sh
+    ./3rdParty/buildMacDependencies.sh


### PR DESCRIPTION
## Summary
- expand INSTALL with instructions for building the server
- mention helper scripts in `3rdParty` for downloading dependencies

## Testing
- `python3 ./ci_tools/source_code_check.py .`
- `python3 ./ci_tools/trailing_whitespaces_check.py .`


------
https://chatgpt.com/codex/tasks/task_e_68418a6940e0832ea6aef91c8892e3b9